### PR TITLE
Fix contest preflight for experiment metadata dirs

### DIFF
--- a/experiments/seq10l_fp16_sliding_challenger/README.md
+++ b/experiments/seq10l_fp16_sliding_challenger/README.md
@@ -1,0 +1,11 @@
+# seq10l fp16 sliding challenger
+
+This experiment wrapper delegates to the record-derived 10-layer fp16 tied-embedding
+sliding-window recipe and sets canary-friendly defaults for ARENA-style battles.
+
+Default behavior:
+- `EVAL_STRIDE=64`
+- `EVAL_BATCH_SEQS=64`
+
+The actual trainer lives in:
+- `records/track_10min_16mb/2026-03-19_SlidingWindow_FP16Emb_10L_MuonWD_OvertoneInit/train_gpt.py`

--- a/experiments/seq10l_fp16_sliding_eval1408/README.md
+++ b/experiments/seq10l_fp16_sliding_eval1408/README.md
@@ -1,0 +1,13 @@
+# seq10l fp16 sliding eval1408
+
+This experiment wrapper reuses the record-derived 10-layer fp16 tied-embedding
+sliding-window recipe and overrides evaluation defaults for a moderate-context
+`1408`-token sliding-window canary.
+
+Default behavior:
+- `EVAL_SEQ_LEN=1408`
+- `EVAL_STRIDE=64`
+- `EVAL_BATCH_SEQS=64`
+
+The actual trainer lives in:
+- `records/track_10min_16mb/2026-03-19_SlidingWindow_FP16Emb_10L_MuonWD_OvertoneInit/train_gpt.py`

--- a/tools/contest_preflight.py
+++ b/tools/contest_preflight.py
@@ -13,6 +13,7 @@ LOG_PATTERNS = ("train*.log", "train*.txt")
 MIN_SUBMISSION_KEYS = ("author", "name")
 METRIC_KEYS = ("val_bpb", "mean_val_bpb", "val_loss", "mean_val_loss")
 BYTE_KEYS = ("bytes_total", "artifact_bytes", "code_bytes", "bytes_code")
+EXPERIMENT_METADATA_DIRS = {"arena_runs", "champions"}
 
 
 def find_candidate_dirs(root: Path) -> list[Path]:
@@ -21,7 +22,11 @@ def find_candidate_dirs(root: Path) -> list[Path]:
         for track_dir in sorted(root.glob("track_*")):
             candidates.extend(sorted(path for path in track_dir.iterdir() if path.is_dir()))
         return candidates
-    return sorted(path for path in root.iterdir() if path.is_dir())
+    return sorted(
+        path
+        for path in root.iterdir()
+        if path.is_dir() and path.name not in EXPERIMENT_METADATA_DIRS
+    )
 
 
 def gather_log_files(path: Path) -> list[Path]:


### PR DESCRIPTION
## Summary
- ignore metadata-only experiment directories like `arena_runs` and `champions` in contest preflight
- add README stubs for wrapper experiments that are intended to be valid experiment folders

## Why
Current PRs are blocked by false-negative preflight failures rather than real code issues.