### PR TITLE
Add train1408 max-batch challenger wrapper

### DIFF
--- a/experiments/seq10l_fp16_train1408_maxbatch/README.md
+++ b/experiments/seq10l_fp16_train1408_maxbatch/README.md
@@ -1,0 +1,16 @@
+# seq10l fp16 train1408 maxbatch
+
+This experiment wrapper reuses the record-derived 10-layer fp16 tied-embedding
+sliding-window recipe and keeps the `1408`-token learned context while raising
+the training batch to the largest clean 8-way multiple used for the next
+same-family ARENA canary.
+
+Default behavior:
+- `TRAIN_SEQ_LEN=1408`
+- `TRAIN_BATCH_TOKENS=529408`
+- `EVAL_SEQ_LEN=1408`
+- `EVAL_STRIDE=64`
+- `EVAL_BATCH_SEQS=128`
+
+The actual trainer lives in:
+- `records/track_10min_16mb/2026-03-19_SlidingWindow_FP16Emb_10L_MuonWD_OvertoneInit/train_gpt.py`

--- a/experiments/seq10l_fp16_train1408_maxbatch/train_gpt.py
+++ b/experiments/seq10l_fp16_train1408_maxbatch/train_gpt.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import runpy
+from pathlib import Path
+
+DEFAULTS = {
+    "RUN_ID": "seq10l_fp16_train1408_maxbatch_v0",
+    "TRAIN_SEQ_LEN": "1408",
+    "TRAIN_BATCH_TOKENS": "529408",
+    "EVAL_SEQ_LEN": "1408",
+    "EVAL_STRIDE": "64",
+    "EVAL_BATCH_SEQS": "128",
+}
+
+
+def main() -> None:
+    for key, value in DEFAULTS.items():
+        os.environ.setdefault(key, value)
+
+    target = (
+        Path(__file__).resolve().parents[2]
+        / "records"
+        / "track_10min_16mb"
+        / "2026-03-19_SlidingWindow_FP16Emb_10L_MuonWD_OvertoneInit"
+        / "train_gpt.py"
+    )
+    if not target.exists():
+        raise SystemExit(f"missing delegated trainer: {target}")
+
+    runpy.run_path(str(target), run_name="__main__")
+
+
+if __name__ == "__main__":
+    main()

--- a/runpod/smoke_seq10l_fp16_train1408_maxbatch.sh
+++ b/runpod/smoke_seq10l_fp16_train1408_maxbatch.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export RUN_ID="${RUN_ID:-smoke_seq10l_fp16_train1408_maxbatch}"
+export DATA_PATH="${DATA_PATH:-./data/datasets/fineweb10B_sp1024}"
+export TOKENIZER_PATH="${TOKENIZER_PATH:-./data/tokenizers/fineweb_1024_bpe.model}"
+export VOCAB_SIZE="${VOCAB_SIZE:-1024}"
+export ITERATIONS="${ITERATIONS:-20}"
+export VAL_LOSS_EVERY="${VAL_LOSS_EVERY:-0}"
+export WARMUP_STEPS="${WARMUP_STEPS:-0}"
+export MAX_WALLCLOCK_SECONDS="${MAX_WALLCLOCK_SECONDS:-0}"
+export TRAIN_SEQ_LEN="${TRAIN_SEQ_LEN:-1408}"
+export TRAIN_BATCH_TOKENS="${TRAIN_BATCH_TOKENS:-529408}"
+export EVAL_SEQ_LEN="${EVAL_SEQ_LEN:-1408}"
+export EVAL_BATCH_SEQS="${EVAL_BATCH_SEQS:-128}"
+export EVAL_STRIDE="${EVAL_STRIDE:-64}"
+export PYTORCH_CUDA_ALLOC_CONF="${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}"
+
+NPROC_PER_NODE="${NPROC_PER_NODE:-1}"
+
+torchrun --standalone --nproc_per_node="${NPROC_PER_NODE}" \
+  experiments/seq10l_fp16_train1408_maxbatch/train_gpt.py


### PR DESCRIPTION
## Summary
- add a same-family follow-up challenger for the 1408-context line
- keep sequence length and eval settings fixed
- raise `TRAIN_BATCH_TOKENS` to `529408` for the next ARENA canary

## Notes
- intended as the immediate follow-up if `b09` stays gray rather than clearly promotable
- rebased onto current `main`