### PR TITLE
Add BOS-target masking challenger

### DIFF
--- a/experiments/seq10l_fp16_maskbos/README.md
+++ b/experiments/seq10l_fp16_maskbos/README.md
@@ -1,0 +1,15 @@
+# seq10l_fp16_maskbos
+
+Loss-only challenger that masks `BOS` targets during training while keeping the
+March 19 10-layer FP16-embedding sliding-window champion architecture and eval
+path unchanged.
+
+Hypothesis:
+
+- the trainer currently spends capacity learning cross-document transitions into
+  the synthetic `BOS` token
+- ignoring those targets should reallocate capacity toward in-document token
+  prediction with a small positive effect on `post_quant_val_bpb`
+
+This wrapper is meant for ARENA-style control/treatment testing, not yet a
+submission record.

--- a/experiments/seq10l_fp16_maskbos/train_gpt.py
+++ b/experiments/seq10l_fp16_maskbos/train_gpt.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+DEFAULTS = {
+    "RUN_ID": "seq10l_fp16_maskbos_v0",
+    "MASK_BOS_TARGETS": "1",
+    "EVAL_STRIDE": "64",
+    "EVAL_BATCH_SEQS": "64",
+}
+
+BOS_ID = 1
+
+
+def load_champion_module(module_path: Path):
+    spec = importlib.util.spec_from_file_location("seq10l_fp16_champion", module_path)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"unable to load delegated trainer: {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def patch_masked_loss(module) -> None:
+    def masked_forward(self, input_ids, target_ids):
+        x = self.tok_emb(input_ids)
+        x = module.F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips = []
+
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, x0)
+            skips.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self.blocks[self.num_encoder_layers + i](x, x0)
+
+        x_norm = self.final_norm(x)
+        x_flat = x_norm.reshape(-1, x_norm.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = module.F.linear(x_flat, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x_flat)
+        logits = self.logit_softcap * module.torch.tanh(logits_proj / self.logit_softcap)
+        per_token = module.F.cross_entropy(logits.float(), targets, reduction="none")
+
+        if os.environ.get("MASK_BOS_TARGETS", "1") != "1":
+            return per_token.mean()
+
+        keep = (targets != BOS_ID).to(dtype=per_token.dtype)
+        return (per_token * keep).sum() / keep.sum().clamp_min(1.0)
+
+    module.GPT.forward = masked_forward
+
+
+def main() -> None:
+    for key, value in DEFAULTS.items():
+        os.environ.setdefault(key, value)
+
+    champion_path = (
+        Path(__file__).resolve().parents[2]
+        / "records"
+        / "track_10min_16mb"
+        / "2026-03-19_SlidingWindow_FP16Emb_10L_MuonWD_OvertoneInit"
+        / "train_gpt.py"
+    )
+    if not champion_path.exists():
+        raise SystemExit(f"missing delegated trainer: {champion_path}")
+
+    champion = load_champion_module(champion_path)
+    patch_masked_loss(champion)
+    champion.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/runpod/smoke_seq10l_fp16_maskbos.sh
+++ b/runpod/smoke_seq10l_fp16_maskbos.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export RUN_ID="${RUN_ID:-smoke_seq10l_fp16_maskbos}"
+export DATA_PATH="${DATA_PATH:-./data/datasets/fineweb10B_sp1024}"
+export TOKENIZER_PATH="${TOKENIZER_PATH:-./data/tokenizers/fineweb_1024_bpe.model}"
+export VOCAB_SIZE="${VOCAB_SIZE:-1024}"
+export ITERATIONS="${ITERATIONS:-20}"
+export VAL_LOSS_EVERY="${VAL_LOSS_EVERY:-0}"
+export WARMUP_STEPS="${WARMUP_STEPS:-0}"
+export MAX_WALLCLOCK_SECONDS="${MAX_WALLCLOCK_SECONDS:-0}"
+export MASK_BOS_TARGETS="${MASK_BOS_TARGETS:-1}"
+export EVAL_STRIDE="${EVAL_STRIDE:-64}"
+export EVAL_BATCH_SEQS="${EVAL_BATCH_SEQS:-64}"
+export PYTORCH_CUDA_ALLOC_CONF="${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}"
+
+NPROC_PER_NODE="${NPROC_PER_NODE:-1}"
+
+torchrun --standalone --nproc_per_node="${NPROC_PER_NODE}" \
+  experiments/seq10l_fp16_maskbos/train_gpt.py


### PR DESCRIPTION
## Summary
- add a loss-only ARENA challenger that masks BOS targets during training
- keep the March 19 10-layer champion architecture and eval path unchanged
- add a matching RunPod smoke launcher and README

## Testing
- python -m py_compile experiments/seq10l_fp16_maskbos/train_gpt.py
- python tools/contest_preflight.py experiments/seq10l_fp16_maskbos
