### PR TITLE
Fix ARENA control arm labeling

### DIFF
--- a/runpod/run_arena_treatment_battle.py
+++ b/runpod/run_arena_treatment_battle.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import copy
 import json
 import os
 import statistics
@@ -79,6 +80,8 @@ def run_one(seed: int, battle_id: str, log_dir: Path) -> dict[str, Any]:
 
 def build_summary(battle_id: str, replicates: list[dict[str, Any]]) -> dict[str, Any]:
     champion = json.loads(CHAMPION_PATH.read_text(encoding="utf-8"))
+    champion_arm = copy.deepcopy(champion["arm"])
+    champion_arm["arm_id"] = "CONTROL"
     successes = [rep for rep in replicates if rep["status"] == "passed"]
     treatment_slug = treatment_name()
     treatment_script_target = treatment_target()
@@ -147,7 +150,7 @@ def build_summary(battle_id: str, replicates: list[dict[str, Any]]) -> dict[str,
             "treatment_failures": len(replicates) - len(successes),
         },
         "arms": [
-            champion["arm"],
+            champion_arm,
             {
                 "arm_id": "TREATMENT",
                 "run_name": f"{treatment_slug}_battle_{battle_id}",


### PR DESCRIPTION
## Summary
- deep-copy the promoted champion arm before inserting it into a new battle summary
- relabel the copied arm as CONTROL so downstream merge logic can distinguish arms correctly

## Testing
- python - <<'PY'
import importlib.util
from pathlib import Path
path = Path('runpod/run_arena_treatment_battle.py')
spec = importlib.util.spec_from_file_location('arena_battle', path)
mod = importlib.util.module_from_spec(spec)
spec.loader.exec_module(mod)
summary = mod.build_summary('sanity', [])
print([arm['arm_id'] for arm in summary['arms']])
PY
