### PR TITLE
Add serious WDQ control lane and research frontier memo

### DIFF
--- a/docs/research/parameter-golf-wild-frontier-2026-03-20.md
+++ b/docs/research/parameter-golf-wild-frontier-2026-03-20.md
@@ -1,0 +1,92 @@
+# Parameter Golf Wild Frontier
+
+Date: March 20, 2026
+
+## Objective
+
+Move from the fast smoke lane, which is currently hovering near `3.46` bpb, to
+a serious lane that can realistically hit `<= 2.0` and then explore wild ideas
+against a strong control.
+
+## Current Ground Truth
+
+- Fast ARENA champion:
+  - [experiments/champions/current_champion.json](/home/warrenjo/src/parameter-golf/experiments/champions/current_champion.json)
+  - useful for cheap direction-finding, not for score targets like `2.0`
+- Strongest checked-in record in this repo:
+  - [records/track_10min_16mb/2026-03-19_WarmdownQuantization/submission.json](/home/warrenjo/src/parameter-golf/records/track_10min_16mb/2026-03-19_WarmdownQuantization/submission.json)
+  - `val_bpb = 1.15744040`
+- Current detached smoke battle:
+  - `b11a` and `b11b`
+  - treatment = `train1408_maxbatch`
+
+## 10-Lens Research Synthesis
+
+Archived specialist passes:
+
+- Long-context:
+  - `train1408_maxbatch` is the cleanest same-family follow-up to `train1408`
+- Quantization:
+  - sensitivity-aware mixed precision remains attractive, especially around
+    output-path tensors
+- Schedule:
+  - `sched400` is the safe schedule-only follow-up, not `sched20`
+- Loss/data:
+  - masking `BOS` targets is a clean orthogonal loss-side bet
+
+Live researcher passes:
+
+- Architecture:
+  - best bounded wild branch is `5x2` shared-depth with tiny loop-specific LoRA
+- Eval/test-time compute:
+  - best high-upside wild branch is porting LoRA TTT eval onto the stronger
+    current backbone
+- Systems:
+  - best correctness-preserving speed lever is exact cached sliding-window eval
+- Orchestration:
+  - detached background battle execution is the stable default path
+- Compression:
+  - layout-adaptive export is a clean next codec-side idea
+- Symmetry:
+  - mirrored or phase-aware tying is still a viable structural branch
+
+## Ranked Frontier
+
+1. Serious control lane: `WarmdownQuantization`
+   - [records/track_10min_16mb/2026-03-19_WarmdownQuantization/train_gpt.py](/home/warrenjo/src/parameter-golf/records/track_10min_16mb/2026-03-19_WarmdownQuantization/train_gpt.py)
+   - reason: repo-proven path to far below `2.0`
+
+2. Wild score branch: `WarmdownQuantization + LoRA TTT eval`
+   - base:
+     [records/track_10min_16mb/2026-03-19_WarmdownQuantization/train_gpt.py](/home/warrenjo/src/parameter-golf/records/track_10min_16mb/2026-03-19_WarmdownQuantization/train_gpt.py)
+   - evaluator to port:
+     [records/track_10min_16mb/2026-03-17_LoRA_TTT/train_gpt.py](/home/warrenjo/src/parameter-golf/records/track_10min_16mb/2026-03-17_LoRA_TTT/train_gpt.py)
+   - reason: biggest plausible score jump from repo-native ideas
+
+3. Wild architecture branch: `5x2 loop-lora maxbatch`
+   - base:
+     [records/track_10min_16mb/2026-03-19_SlidingWindow_FP16Emb_10L_MuonWD_OvertoneInit/train_gpt.py](/home/warrenjo/src/parameter-golf/records/track_10min_16mb/2026-03-19_SlidingWindow_FP16Emb_10L_MuonWD_OvertoneInit/train_gpt.py)
+   - recurrence ingredients:
+     [records/track_10min_16mb/2026-03-19_SlidingWindowEval/train_gpt.py](/home/warrenjo/src/parameter-golf/records/track_10min_16mb/2026-03-19_SlidingWindowEval/train_gpt.py)
+
+4. Eval systems branch: exact cached sliding-window eval
+   - reason: not a score trick by itself, but it makes wild eval-heavy ideas
+     cheaper and cleaner to test
+
+5. Codec branch: layout-adaptive export on quantized tensors
+   - reason: bounded, challenge-legal, and synergistic with near-cap models
+
+## Immediate Sequence
+
+1. Keep the detached smoke ARENA loop running for cheap attribution.
+2. Promote a serious control lane around `WarmdownQuantization`.
+3. Build the first truly wild branch against that serious lane:
+   `WarmdownQuantization + LoRA TTT eval`.
+4. Keep `BOS` masking, `sched400`, and layout-adaptive export as orthogonal
+   side branches, not mixed into the same treatment.
+
+## New Files In This Branch
+
+- [experiments/wdq_serious_control/train_gpt.py](/home/warrenjo/src/parameter-golf/experiments/wdq_serious_control/train_gpt.py)
+- [experiments/wdq_serious_control/README.md](/home/warrenjo/src/parameter-golf/experiments/wdq_serious_control/README.md)
+- [runpod/serious_wdq_control_single_h100.sh](/home/warrenjo/src/parameter-golf/runpod/serious_wdq_control_single_h100.sh)

--- a/experiments/wdq_serious_control/README.md
+++ b/experiments/wdq_serious_control/README.md
@@ -1,0 +1,15 @@
+# wdq_serious_control
+
+Serious-control wrapper around the strongest checked-in record family in this
+repo: `2026-03-19_WarmdownQuantization`.
+
+Default intent:
+
+- train on the stronger `train@2048` / `eval@1408` family
+- use the warmdown-for-compression schedule from the record
+- preserve the record's `int6 + fp16 tied embedding + late-K passthrough`
+  export path
+
+This is not a new record submission. It exists to establish a realistic
+sub-`2.0` control lane on available RunPod H100s while the fast ARENA smoke lane
+continues exploring smaller ideas.

--- a/experiments/wdq_serious_control/train_gpt.py
+++ b/experiments/wdq_serious_control/train_gpt.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import os
+import runpy
+from pathlib import Path
+
+DEFAULTS = {
+    "RUN_ID": "wdq_serious_control_v0",
+    "TRAIN_SEQ_LEN": "2048",
+    "EVAL_SEQ_LEN": "1408",
+    "EVAL_STRIDE": "64",
+    "WARMDOWN_ITERS": "20000",
+    "MATRIX_LR": "0.06",
+    "TIED_EMBED_LR": "0.07",
+    "SCALAR_LR": "0.06",
+    "GRAD_CLIP_NORM": "1.0",
+    "MUON_BACKEND_STEPS": "5",
+    "MLP_HIDDEN": "992",
+}
+
+
+def main() -> None:
+    for key, value in DEFAULTS.items():
+        os.environ.setdefault(key, value)
+
+    target = (
+        Path(__file__).resolve().parents[2]
+        / "records"
+        / "track_10min_16mb"
+        / "2026-03-19_WarmdownQuantization"
+        / "train_gpt.py"
+    )
+    if not target.exists():
+        raise SystemExit(f"missing delegated trainer: {target}")
+
+    runpy.run_path(str(target), run_name="__main__")
+
+
+if __name__ == "__main__":
+    main()

--- a/runpod/serious_wdq_control_single_h100.sh
+++ b/runpod/serious_wdq_control_single_h100.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export RUN_ID="${RUN_ID:-serious_wdq_control_single_h100}"
+export DATA_PATH="${DATA_PATH:-./data/datasets/fineweb10B_sp1024}"
+export TOKENIZER_PATH="${TOKENIZER_PATH:-./data/tokenizers/fineweb_1024_bpe.model}"
+export VOCAB_SIZE="${VOCAB_SIZE:-1024}"
+export ITERATIONS="${ITERATIONS:-20000}"
+export MAX_WALLCLOCK_SECONDS="${MAX_WALLCLOCK_SECONDS:-1800}"
+export VAL_LOSS_EVERY="${VAL_LOSS_EVERY:-200}"
+export TRAIN_LOG_EVERY="${TRAIN_LOG_EVERY:-50}"
+export TRAIN_SEQ_LEN="${TRAIN_SEQ_LEN:-2048}"
+export EVAL_SEQ_LEN="${EVAL_SEQ_LEN:-1408}"
+export EVAL_STRIDE="${EVAL_STRIDE:-64}"
+export WARMDOWN_ITERS="${WARMDOWN_ITERS:-20000}"
+export MATRIX_LR="${MATRIX_LR:-0.06}"
+export TIED_EMBED_LR="${TIED_EMBED_LR:-0.07}"
+export SCALAR_LR="${SCALAR_LR:-0.06}"
+export GRAD_CLIP_NORM="${GRAD_CLIP_NORM:-1.0}"
+export MUON_BACKEND_STEPS="${MUON_BACKEND_STEPS:-5}"
+export MLP_HIDDEN="${MLP_HIDDEN:-992}"
+export PYTORCH_CUDA_ALLOC_CONF="${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}"
+
+NPROC_PER_NODE="${NPROC_PER_NODE:-1}"
+
+torchrun --standalone --nproc_per_node="${NPROC_PER_NODE}" \
+  experiments/wdq_serious_control/train_gpt.py


### PR DESCRIPTION
## Summary
- add a serious-control wrapper around the strongest checked-in WarmdownQuantization record family
- add a single-H100 RunPod launcher for that control lane
- save the current deep-research frontier and ranked next branches in a local memo

## Testing
- python -m py_compile experiments/wdq_serious_control/train_gpt.py
- python tools/contest_preflight.py experiments/wdq_serious_control
