### PR TITLE
Add WDQ layout-adaptive export challenger

### DIFF
--- a/experiments/wdq_layout_adaptive_export/README.md
+++ b/experiments/wdq_layout_adaptive_export/README.md
@@ -1,0 +1,14 @@
+# wdq_layout_adaptive_export
+
+Wild-but-bounded treatment on top of the `WarmdownQuantization` family.
+
+Training stays unchanged. The only intervention is export layout selection for
+large 2D quantized tensors:
+
+- quantize as usual
+- compare compressed size of `q` vs `q.T.contiguous()`
+- store the smaller layout
+- transpose back during dequantization if needed
+
+This is aimed at improving serialized artifact efficiency without changing model
+semantics.

--- a/experiments/wdq_layout_adaptive_export/train_gpt.py
+++ b/experiments/wdq_layout_adaptive_export/train_gpt.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import copy
+import importlib.util
+import os
+import zlib
+from pathlib import Path
+
+DEFAULTS = {
+    "RUN_ID": "wdq_layout_adaptive_export_v0",
+    "TRAIN_SEQ_LEN": "2048",
+    "EVAL_SEQ_LEN": "1408",
+    "EVAL_STRIDE": "64",
+    "WARMDOWN_ITERS": "20000",
+    "MATRIX_LR": "0.06",
+    "TIED_EMBED_LR": "0.07",
+    "SCALAR_LR": "0.06",
+    "GRAD_CLIP_NORM": "1.0",
+    "MUON_BACKEND_STEPS": "5",
+    "MLP_HIDDEN": "992",
+    "LAYOUT_ADAPTIVE_MIN_NUMEL": "16384",
+}
+
+
+def load_module(module_path: Path):
+    spec = importlib.util.spec_from_file_location("wdq_train_gpt", module_path)
+    if spec is None or spec.loader is None:
+        raise SystemExit(f"unable to load delegated trainer: {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def patch_layout_adaptive_export(module) -> None:
+    min_numel = int(os.environ.get("LAYOUT_ADAPTIVE_MIN_NUMEL", "16384"))
+    original_quantize = module.quantize_state_dict_int8
+    original_dequantize = module.dequantize_state_dict_int8
+
+    def compressed_len(q) -> int:
+        return len(zlib.compress(q.numpy().tobytes(), level=1))
+
+    def quantize_state_dict_int8(state_dict):
+        obj, stats = original_quantize(state_dict)
+        qmeta = dict(obj.get("qmeta", {}))
+        changed = False
+        for name, q in list(obj["quantized"].items()):
+            if q.ndim != 2 or q.numel() < min_numel:
+                continue
+            q_t = q.T.contiguous()
+            if compressed_len(q_t) >= compressed_len(q):
+                continue
+            obj["quantized"][name] = q_t
+            meta = dict(qmeta.get(name, {}))
+            meta["stored_transposed"] = True
+            qmeta[name] = meta
+            changed = True
+        if changed:
+            obj["qmeta"] = qmeta
+        return obj, stats
+
+    def dequantize_state_dict_int8(obj):
+        qmeta = obj.get("qmeta", {})
+        needs_fix = any(meta.get("stored_transposed") for meta in qmeta.values())
+        if not needs_fix:
+            return original_dequantize(obj)
+
+        fixed = copy.deepcopy(obj)
+        for name, meta in fixed.get("qmeta", {}).items():
+            if meta.get("stored_transposed"):
+                fixed["quantized"][name] = fixed["quantized"][name].T.contiguous()
+                meta = dict(meta)
+                meta.pop("stored_transposed", None)
+                fixed["qmeta"][name] = meta
+        return original_dequantize(fixed)
+
+    module.quantize_state_dict_int8 = quantize_state_dict_int8
+    module.dequantize_state_dict_int8 = dequantize_state_dict_int8
+
+
+def main() -> None:
+    for key, value in DEFAULTS.items():
+        os.environ.setdefault(key, value)
+
+    target = (
+        Path(__file__).resolve().parents[2]
+        / "records"
+        / "track_10min_16mb"
+        / "2026-03-19_WarmdownQuantization"
+        / "train_gpt.py"
+    )
+    if not target.exists():
+        raise SystemExit(f"missing delegated trainer: {target}")
+
+    module = load_module(target)
+    patch_layout_adaptive_export(module)
+    module.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/runpod/serious_wdq_layout_single_h100.sh
+++ b/runpod/serious_wdq_layout_single_h100.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export RUN_ID="${RUN_ID:-serious_wdq_layout_single_h100}"
+export DATA_PATH="${DATA_PATH:-./data/datasets/fineweb10B_sp1024}"
+export TOKENIZER_PATH="${TOKENIZER_PATH:-./data/tokenizers/fineweb_1024_bpe.model}"
+export VOCAB_SIZE="${VOCAB_SIZE:-1024}"
+export ITERATIONS="${ITERATIONS:-20000}"
+export MAX_WALLCLOCK_SECONDS="${MAX_WALLCLOCK_SECONDS:-1800}"
+export VAL_LOSS_EVERY="${VAL_LOSS_EVERY:-200}"
+export TRAIN_LOG_EVERY="${TRAIN_LOG_EVERY:-50}"
+export TRAIN_SEQ_LEN="${TRAIN_SEQ_LEN:-2048}"
+export EVAL_SEQ_LEN="${EVAL_SEQ_LEN:-1408}"
+export EVAL_STRIDE="${EVAL_STRIDE:-64}"
+export WARMDOWN_ITERS="${WARMDOWN_ITERS:-20000}"
+export MATRIX_LR="${MATRIX_LR:-0.06}"
+export TIED_EMBED_LR="${TIED_EMBED_LR:-0.07}"
+export SCALAR_LR="${SCALAR_LR:-0.06}"
+export GRAD_CLIP_NORM="${GRAD_CLIP_NORM:-1.0}"
+export MUON_BACKEND_STEPS="${MUON_BACKEND_STEPS:-5}"
+export MLP_HIDDEN="${MLP_HIDDEN:-992}"
+export LAYOUT_ADAPTIVE_MIN_NUMEL="${LAYOUT_ADAPTIVE_MIN_NUMEL:-16384}"
+export PYTORCH_CUDA_ALLOC_CONF="${PYTORCH_CUDA_ALLOC_CONF:-expandable_segments:True}"
+
+NPROC_PER_NODE="${NPROC_PER_NODE:-1}"
+
+torchrun --standalone --nproc_per_node="${NPROC_PER_NODE}" \
+  experiments/wdq_layout_adaptive_export/train_gpt.py


### PR DESCRIPTION
## Summary
- add a WarmdownQuantization-derived challenger that chooses the best storage layout/filter per large quantized matrix
- keep training semantics unchanged and only alter export/dequant roundtrip handling
- prepare a serious single-H100 launcher for the codec-only treatment

## Testing
- python -m py_compile experiments/wdq_layout_adaptive_export/train_gpt.py
- python tools/contest_preflight.py experiments/wdq_layout_adaptive_export
